### PR TITLE
upd: changed to new versions of mods (buildcraft, galacticraft)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -16,6 +16,10 @@ buildscript {
 }
 
 repositories {
+    ivy {
+        name "BuildCraft"
+        artifactPattern "http://www.mod-buildcraft.com/releases/BuildCraft/[revision]/[module]-[revision]-[classifier].[ext]"
+    }
     maven {
         name = "chickenbones"
         url = "http://chickenbones.net/maven"
@@ -28,12 +32,11 @@ repositories {
 
 apply plugin: 'forge'
 
-
-
-version = "0.4.8"
+version = "0.4.9"
 group = "de.katzenpapst.amunra" // http://maven.apache.org/guides/mini/guide-naming-conventions.html
 archivesBaseName = "AmunRa-GC"
-def gc_version = "3.0.12.498"
+def gc_version = "3.0.12.502"
+def bc_version = "7.1.22"
 
 sourceCompatibility = JavaVersion.VERSION_1_8
 targetCompatibility = JavaVersion.VERSION_1_8
@@ -73,14 +76,13 @@ dependencies {
     compile ("com.enderio:EnderIO:1.7.10-2.3.0.429_beta:dev" ) {
         transitive = false
     }
-    compile "com.mod-buildcraft:buildcraft:6.1.5:api"
+    compile name: "buildcraft", version: "${bc_version}", classifier: "dev"    
     
     compile files("libs/MicdoodleCore-Dev-1.7-${gc_version}.jar")
     compile files("libs/Galacticraft-API-1.7-${gc_version}.jar")
     compile files("libs/GalacticraftCore-Dev-${gc_version}.jar")
     compile files("libs/Galacticraft-Planets-Dev-${gc_version}.jar")
-    
-    
+
 }
 
 dependencies {

--- a/src/main/java/de/katzenpapst/amunra/block/SubBlockDropItem.java
+++ b/src/main/java/de/katzenpapst/amunra/block/SubBlockDropItem.java
@@ -85,13 +85,13 @@ public class SubBlockDropItem extends SubBlock {
     @Override
     public int damageDropped(int meta)
     {
-        return droppedItems.getDamage();
+        return droppedItems != null ? droppedItems.getDamage() : super.damageDropped(meta);
     }
 
     @Override
     public Item getItemDropped(int meta, Random random, int fortune)
     {
-        return droppedItems.getItem();
+        return droppedItems != null ? droppedItems.getItem() : super.getItemDropped(meta, random, fortune);
     }
 
     public SubBlockDropItem setDroppedItem(Item item) {


### PR DESCRIPTION
err: fixed NullPointerException, found during parsing of recipies in NEI

Hello Katzenpapst,
I found and fixed a NullPointerException in SubDropBlockItem. We have a server with a lot of mods (ca. 250). During parsing of recipies minecraft crashed with a NullPointerException (droppedItems was null).

Additionally I changed the build.gradle
- new version 0.4.9
- galacticraft 3.0.12.502
- buildcraft 7.1.22 (needs ivy definition in repositories)

Best regards
Zetti68